### PR TITLE
paint collision in actordefs

### DIFF
--- a/src/dreaditor/actor.py
+++ b/src/dreaditor/actor.py
@@ -66,10 +66,6 @@ class Actor:
             level_data.vPos[0] - DOT_SIZE, -level_data.vPos[1] - DOT_SIZE, 2 * DOT_SIZE, 2 * DOT_SIZE
         )
 
-        # avoid crashing on the one broken actordef
-        if bmsadLink == "actors/props/pf_mushr_fr/charclasses/pf_mushr_fr.bmsad":
-            return
-
         self.bmsad = editor.get_parsed_asset(bmsadLink, type_hint=Bmsad)
         if "COLLISION" in self.bmsad.components:
             coll: str = self.bmsad.components["COLLISION"].dependencies.file

--- a/src/dreaditor/painters/custom_painters.py
+++ b/src/dreaditor/painters/custom_painters.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from PySide6.QtCore import QRectF
 
 from dreaditor.config import get_config_data
-from dreaditor.painters.collision import paint_all_collision, paint_door, paint_tiles
+from dreaditor.painters.collision import paint_all_collision, paint_bmsad_functions, paint_door, paint_tiles
 from dreaditor.painters.logicpath import paint_logicpath
 from dreaditor.painters.logicshape import paint_logicshape
 from dreaditor.painters.worldgraph import paint_worldgraph
@@ -32,6 +32,10 @@ def custom_painters(
     elif actor.bmscc:
         if actor.isSelected or get_config_data("paintCollision"):
             rect = rect.united(paint_all_collision(actor, painter, option, widget))
+
+    if actor.bmsad and actor.bmsad.components.get("COLLISION"):
+        if actor.isSelected or get_config_data("paintCollision"):
+            rect = rect.united(paint_bmsad_functions(actor, painter, option, widget))
 
     if actor.getComponent("CBreakableTileGroupComponent"):
         if actor.isSelected or get_config_data("paintBreakables"):

--- a/src/dreaditor/painters/logicshape.py
+++ b/src/dreaditor/painters/logicshape.py
@@ -40,8 +40,10 @@ def paint_logicshape(
 
             if poly.bClosed:
                 qpoly.append(qpoly.first())
+                painter.drawPolygon(qpoly)
+            else:
+                painter.drawPolyline(qpoly)
 
-            painter.drawPolygon(qpoly)
             rect = rect.united(qpoly.boundingRect())
     elif ls_type == "game::logic::collision::CAABoxShape2D":
         p1 = vPos + QPointF(logicshape_comp.pLogicShape.v2Min[0], -logicshape_comp.pLogicShape.v2Min[1])


### PR DESCRIPTION
- only version used in game is AABOX2D (save station platforms)
- fixes an issue where logicshape polygons' bClosed was not respected, incorrectly rendering things like magnet walls
- removes the restriction on rendering ghavoran mushroom platforms since the underlying error was resolved in MEDS
 
resolves #6 