### PR TITLE
collapse SubareaTreeWidgetItems better

### DIFF
--- a/src/dreaditor/widgets/actor_list_tree.py
+++ b/src/dreaditor/widgets/actor_list_tree.py
@@ -70,6 +70,14 @@ class ActorListTree(QTreeWidget):
 
         return None
 
+    def item_depth(self, item: QTreeWidgetItem):
+        depth = 0
+        curr_item = item.parent()  # so root is 0 depth
+        while curr_item:
+            depth += 1
+            curr_item = curr_item.parent()
+        return depth
+
     @Slot(QTreeWidgetItem, int)
     def onItemChanged(self, item: QTreeWidgetItem, col):
         if isinstance(item, EntityListTreeWidgetItem):

--- a/src/dreaditor/widgets/subareas_list_tree.py
+++ b/src/dreaditor/widgets/subareas_list_tree.py
@@ -58,3 +58,8 @@ class SubareasListTree(ActorListTree):
         if isinstance(item, SubareaTreeWidgetItem):
             if item.collision_camera_item:
                 item.collision_camera_item.request_disable()
+
+        # un-expand all items below cc level (root node, setup id, cameras)
+        if self.item_depth(item) < 2:
+            for i in range(item.childCount()):
+                item.child(i).setExpanded(False)


### PR DESCRIPTION
- added a function to ActorListTree to get the depth of an item
- added code to collapse all item children in SubareaListTree at collision camera level or above when an item is collapsed
- fixes #19