### PR TITLE
collision cameras focus on opening

### DIFF
--- a/src/dreaditor/widgets/collision_camera_item.py
+++ b/src/dreaditor/widgets/collision_camera_item.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtCore import QPointF, QRectF, Qt
 from PySide6.QtGui import QColor, QFont, QFontMetricsF, QPainter, QPen, QPolygonF
 from PySide6.QtWidgets import QGraphicsItem, QStyleOptionGraphicsItem, QWidget
 
 from dreaditor.config import CurrentConfiguration
 
 COLLISION_CAMERA_COLOR = QColor(255, 200, 255, 255)
+PADDING_PCT = 0.95
 
 
 class CollisionCameraItem(QGraphicsItem):
@@ -49,6 +50,10 @@ class CollisionCameraItem(QGraphicsItem):
         self.num_active_cameras += 1
         if self.num_active_cameras == 1:
             self.update()
+
+        scene_view = self.scene().views()[0]
+        scene_view.fitInView(self, Qt.AspectRatioMode.KeepAspectRatio)
+        scene_view.scale(PADDING_PCT, PADDING_PCT)
 
     def request_disable(self):
         self.num_active_cameras -= 1

--- a/src/dreaditor/widgets/scenario_viewer.py
+++ b/src/dreaditor/widgets/scenario_viewer.py
@@ -41,6 +41,7 @@ class ScenarioViewer(QGraphicsView):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setBackgroundBrush(BACKGROUND)
         self.setViewportUpdateMode(self.ViewportUpdateMode.FullViewportUpdate)
+        self.setTransformationAnchor(self.ViewportAnchor.AnchorUnderMouse)
 
     def on_new_scenario_selected(self, scenario: Scenario):
         self.scene().clear()
@@ -70,13 +71,5 @@ class ScenarioViewer(QGraphicsView):
         )
 
     def wheelEvent(self, event: QWheelEvent | None) -> None:
-        oldPos = self.mapToScene(event.position().toPoint())
-
         zoomFactor = ZOOM_FACTOR if event.angleDelta().y() > 0 else 1 / ZOOM_FACTOR
-
         self.scale(zoomFactor, zoomFactor)
-
-        newPos = self.mapToScene(event.position().toPoint())
-
-        delta = newPos - oldPos
-        self.translate(delta.x(), delta.y())


### PR DESCRIPTION
- when a cc is expanded in the subtree view the graphics view focuses on it
- fixed a bug where the camera would zoom from the center instead of the mouse center
- fixes #33